### PR TITLE
Add Linux AArch64 wheel build support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,16 +4,24 @@ on: [push, pull_request]
 
 jobs:
   build_wheels:
-    name: Build wheel on ${{ matrix.os }}
+    name: Build wheel on ${{ matrix.os }} for ${{ matrix.arch }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        arch: [auto]
+        include:
+        - os: ubuntu-latest
+          arch: aarch64
 
     steps:
     - uses: actions/checkout@master
       with:
         submodules: 'recursive'
+
+    - name: Set up QEMU
+      if: ${{ matrix.arch == 'aarch64' }}
+      uses: docker/setup-qemu-action@v1
 
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.0.2
@@ -33,12 +41,13 @@ jobs:
     - name: Build wheels
       env:
         CIBW_BUILD: "cp3?-*"
-        CIBW_SKIP: "*-win32 *-manylinux_i686"
+        CIBW_SKIP: "*-win32 *-manylinux_i686 cp35-* *-musllinux*"
+        CIBW_ARCHS: ${{ matrix.arch }}
         CIBW_MANYLINUX_X86_64_IMAGE: "dockcross/manylinux2014-x64"
         CIBW_TEST_REQUIRES: "pytest"
         CIBW_TEST_COMMAND: "pytest {project}/tests"
       run: |
-        python -m pip install cibuildwheel==1.7.4
+        python -m pip install cibuildwheel==2.3.1
         python -m cibuildwheel --output-dir wheelhouse
 
     - name: Build source


### PR DESCRIPTION
Added linux aarch64 wheel build support.
Related to https://github.com/osqp/qdldl-python/issues/17, @bstellato Could you please review this PR?