### PR TITLE
Vb/py310

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,9 @@ jobs:
         CIBW_MANYLINUX_X86_64_IMAGE: "dockcross/manylinux2014-x64"
         CIBW_TEST_REQUIRES: "pytest"
         CIBW_TEST_COMMAND: "pytest {project}/tests"
+        CIBW_ENVIRONMENT_LINUX: CMAKE_GENERATOR="Unix Makefiles"
+        CIBW_ENVIRONMENT_MACOS: CMAKE_GENERATOR="Unix Makefiles"
+        CIBW_ENVIRONMENT_WINDOWS: CMAKE_GENERATOR="Visual Studio 2022"
       run: |
         python -m pip install cibuildwheel
         python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         CIBW_TEST_COMMAND: "pytest {project}/tests"
         CIBW_ENVIRONMENT_LINUX: CMAKE_GENERATOR="Unix Makefiles"
         CIBW_ENVIRONMENT_MACOS: CMAKE_GENERATOR="Unix Makefiles"
-        CIBW_ENVIRONMENT_WINDOWS: CMAKE_GENERATOR="Visual Studio 2022"
+        CIBW_ENVIRONMENT_WINDOWS: CMAKE_GENERATOR="Visual Studio 17 2022"
       run: |
         python -m pip install cibuildwheel
         python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         CIBW_TEST_COMMAND: "pytest {project}/tests"
         CIBW_ENVIRONMENT_LINUX: CMAKE_GENERATOR="Unix Makefiles"
         CIBW_ENVIRONMENT_MACOS: CMAKE_GENERATOR="Unix Makefiles"
-        CIBW_ENVIRONMENT_WINDOWS: CMAKE_GENERATOR="Visual Studio 17 2022"
+        CIBW_ENVIRONMENT_WINDOWS: CMAKE_GENERATOR="Visual Studio 17 2022" CMAKE_GENERATOR_PLATFORM=x64
       run: |
         python -m pip install cibuildwheel
         python -m cibuildwheel --output-dir wheelhouse

--- a/setup.py
+++ b/setup.py
@@ -33,23 +33,28 @@ class get_pybind_include(object):
         return pybind11.get_include(self.user)
 
 
+cmake_args = []
+# What variables from the environment do we wish to pass on to cmake as variables?
+cmake_env_vars = ('CMAKE_GENERATOR', )
+for cmake_env_var in cmake_env_vars:
+    cmake_var = os.environ.get(cmake_env_var)
+    if cmake_var:
+        cmake_args.extend([f'-D{cmake_env_var}={cmake_var}'])
+
 # Add parameters to cmake_args and define_macros
-cmake_args = ["-DUNITTESTS=OFF"]
+cmake_args += ["-DUNITTESTS=OFF"]
 cmake_build_flags = []
 lib_subdir = []
 
 # Check if windows linux or mac to pass flag
 if system() == 'Windows':
-    cmake_args += ['-G', 'Visual Studio 14 2015']
-    # Differentiate between 32-bit and 64-bit
     if sys.maxsize // 2 ** 32 > 0:
-        cmake_args[-1] += ' Win64'
+        cmake_args += ['-A', 'x64']
     cmake_build_flags += ['--config', 'Release']
     lib_name = 'qdldlamd.lib'
     lib_subdir = ['Release']
 
 else:  # Linux or Mac
-    cmake_args += ['-G', 'Unix Makefiles']
     lib_name = 'libqdldlamd.a'
 
 # Set optimizer flag

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ class get_pybind_include(object):
 
 cmake_args = []
 # What variables from the environment do we wish to pass on to cmake as variables?
-cmake_env_vars = ('CMAKE_GENERATOR', )
+cmake_env_vars = ('CMAKE_GENERATOR', 'CMAKE_GENERATOR_PLATFORM')
 for cmake_env_var in cmake_env_vars:
     cmake_var = os.environ.get(cmake_env_var)
     if cmake_var:
@@ -48,8 +48,6 @@ lib_subdir = []
 
 # Check if windows linux or mac to pass flag
 if system() == 'Windows':
-    if sys.maxsize // 2 ** 32 > 0:
-        cmake_args += ['-A', 'x64']
     cmake_build_flags += ['--config', 'Release']
     lib_name = 'qdldlamd.lib'
     lib_subdir = ['Release']

--- a/setup.py
+++ b/setup.py
@@ -40,10 +40,10 @@ lib_subdir = []
 
 # Check if windows linux or mac to pass flag
 if system() == 'Windows':
-    cmake_args += ['-G', 'Visual Studio 17 2022']
+    cmake_args += ['-G', 'Visual Studio 14 2015']
     # Differentiate between 32-bit and 64-bit
     if sys.maxsize // 2 ** 32 > 0:
-        cmake_args += ['-A', 'x64']
+        cmake_args[-1] += ' Win64'
     cmake_build_flags += ['--config', 'Release']
     lib_name = 'qdldlamd.lib'
     lib_subdir = ['Release']


### PR DESCRIPTION
Passing CMAKE_GENERATOR to `setup.py` as an envvar. This is to address a concern from a user:

The compiler version shouldn't be hard-coded into setup.py, but dealt with from the CI side. As-is, this makes the package uninstallable on windows with any other version than the very recent VS2022, which is unnecessarily restrictive - and we're hitting this in https://github.com/conda-forge/qdldl-python-feedstock/pull/14, for example.