### PR TITLE
Enable pep517 builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
-requires = ["setuptools>=41.1", "pybind11"]
+requires = ["setuptools>=49.5.0", "pybind11"]
 build-backend = "setuptools.build_meta"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[build-system]
+requires = ["setuptools>=41.1", "pybind11"]
+build-backend = "setuptools.build_meta"
+

--- a/setup.py
+++ b/setup.py
@@ -119,6 +119,7 @@ setup(name='qdldl',
       long_description_content_type='text/markdown',
       package_dir={'qdldl': 'module'},
       include_package_data=True,  # Include package data from MANIFEST.in
+      setup_requires=["setuptools>=18.0", "pybind11"],
       install_requires=["numpy >= 1.7", "scipy >= 0.13.2"],
       license='Apache 2.0',
       url="https://github.com/oxfordcontrol/qdldl-python/",

--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,6 @@ setup(name='qdldl',
       long_description_content_type='text/markdown',
       package_dir={'qdldl': 'module'},
       include_package_data=True,  # Include package data from MANIFEST.in
-      setup_requires=["setuptools>=18.0", "pybind11"],
       install_requires=["numpy >= 1.7", "scipy >= 0.13.2"],
       license='Apache 2.0',
       url="https://github.com/oxfordcontrol/qdldl-python/",


### PR DESCRIPTION
The python ecosystem is slowly [deprecating](https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html) the setup.py file, and moving towards a more flexible build system based on [PEP 517](https://peps.python.org/pep-0517/). Some tools such as [Poetry](https://python-poetry.org/) have decided to enable PEP 517 by default, which means packages which are not compatible and do not provide wheels for every possible architecture cannot be installed (see e.g. #25).

This PR allows `pip install --use-pep517` to work by adding a minimal `pyproject.toml` file.