### PR TITLE
Add pyproject.toml with pybind11 deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["pybind11", "setuptools", "wheel"]
+build-backend = "setuptools.build_meta:__legacy__"


### PR DESCRIPTION
I was trying to install this (as a transitive dep) via Poetry on an M1 Mac / ARM linux container (there are no ARM wheels published) and getting errors with the `pybind11` fallback installation. The error wasn't shown, but I added the install failure message to the error in https://github.com/osqp/qdldl-python/pull/30 to debug. When built with build isolation (which poetry does), `pip` isn't available for the `pybind11` install.

[PEP 517](https://peps.python.org/pep-0517/) introduced `pyproject.toml` which can provide the dependencies required to build a package. I added `pybind11` to the `pyproject.toml` metadata, which ensures it is installed before calling `setup.py`.

---

Here was the command used to install the package and the associated error (with the added message from https://github.com/osqp/qdldl-python/pull/30):
```
$ pip install --use-pep517 'qdldl @ git+https://github.com/dynotx/qdldl-python@fix-setup-deps#egg=qdldl'
Collecting qdldl@ git+https://github.com/dynotx/qdldl-python@fix-setup-deps#egg=qdldl
  Cloning https://github.com/dynotx/qdldl-python (to revision fix-setup-deps) to /tmp/pip-install-dpmsd1ol/qdldl_e2a0e544747a4080a64767c06e487aeb
  Running command git clone --filter=blob:none --quiet https://github.com/dynotx/qdldl-python /tmp/pip-install-dpmsd1ol/qdldl_e2a0e544747a4080a64767c06e487aeb
  Running command git checkout -b fix-setup-deps --track origin/fix-setup-deps
  Switched to a new branch 'fix-setup-deps'
  Branch 'fix-setup-deps' set up to track remote branch 'fix-setup-deps' from 'origin'.
  Resolved https://github.com/dynotx/qdldl-python to commit 7dfd6113cec9bfb857f31b4d6c620bbe7794fe49
  Running command git submodule update --init --recursive -q
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error

  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [25 lines of output]
      Traceback (most recent call last):
        File "<string>", line 24, in __init__
      ModuleNotFoundError: No module named 'pybind11'

      During handling of the above exception, another exception occurred:

      Traceback (most recent call last):
        File ".../lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 351, in <module>
          main()
        File ".../lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 333, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File ".../lib/python3.10/site-packages/pip/_vendor/pep517/in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-26op6h9n/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 338, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
        File "/tmp/pip-build-env-26op6h9n/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 320, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-26op6h9n/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 484, in run_setup
          super(_BuildMetaLegacyBackend,
        File "/tmp/pip-build-env-26op6h9n/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 335, in run_setup
          exec(code, locals())
        File "<string>", line 102, in <module>
        File "<string>", line 29, in __init__
      RuntimeError: pybind11 install failed: .../bin/python3: No module named pip

      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

And here's the successful install after adding the `pyproject.toml`:
```
$ pip install --use-pep517 'qdldl @ git+https://github.com/dynotx/qdldl-python@fix-setup-deps#egg=qdldl'
Collecting qdldl@ git+https://github.com/dynotx/qdldl-python@fix-setup-deps#egg=qdldl
  Cloning https://github.com/dynotx/qdldl-python (to revision fix-setup-deps) to /tmp/pip-install-e2toj2fo/qdldl_50666280434a47b896b71da2e555958f
  Running command git clone --filter=blob:none --quiet https://github.com/dynotx/qdldl-python /tmp/pip-install-e2toj2fo/qdldl_50666280434a47b896b71da2e555958f
  Running command git checkout -b fix-setup-deps --track origin/fix-setup-deps
  Switched to a new branch 'fix-setup-deps'
  Branch 'fix-setup-deps' set up to track remote branch 'fix-setup-deps' from 'origin'.
  Resolved https://github.com/dynotx/qdldl-python to commit fa4bfcc99bf9a81717380a3b26acaa14d8734fa3
  Running command git submodule update --init --recursive -q
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
  Preparing metadata (pyproject.toml) ... done
Building wheels for collected packages: qdldl
  Building wheel for qdldl (pyproject.toml) ... done
  Created wheel for qdldl: filename=qdldl-0.1.5.post0-cp310-cp310-linux_aarch64.whl size=999284 sha256=57da229623c7c15affff98f87b4a390b0cf54d894c8f733d2b7ff716f60f4a51
  Stored in directory: /tmp/pip-ephem-wheel-cache-lwzpbfg4/wheels/ec/ec/91/5fd286aa8ccad685b99503e34f86ca40e632a009f088c7fec8
Successfully built qdldl
Installing collected packages: qdldl
Successfully installed qdldl-0.1.5.post0
```
