### PR TITLE
Add cmake as a build dependency in the pyproject.toml file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [build-system]
-requires = ["setuptools>=49.5.0", "pybind11"]
+requires = ["setuptools>=49.5.0", "pybind11", "cmake"]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
Fixes #26 

Self explanatory fix for issues in the build process. The build process can be improved further by using existing well maintained tools for this sort of thing such as [scikit build](https://scikit-build.readthedocs.io/en/latest/) but just committing the minimum changes required.

If you're not tied to conda I would suggest ignoring it and just using Python's build system - it's not perfect but it's come a long way and means that conda would be supported automatically as well as non-conda users