### PR TITLE
Adds Solver.factors method

### DIFF
--- a/cpp/qdldl.cpp
+++ b/cpp/qdldl.cpp
@@ -48,7 +48,7 @@ Solver::Solver(QDLDL_int n, QDLDL_int * Ap, QDLDL_int *Ai, QDLDL_float * Ax){
 	symperm(n, Ap, Ai, Ax, Aperm_p, Aperm_i, Aperm_x, Pinv, A2Aperm, work_perm);
 
 	// Compute elimination tree
-    int sum_Lnz = QDLDL_etree(n, Aperm_p, Aperm_i, iwork, Lnz, etree);
+    sum_Lnz = QDLDL_etree(n, Aperm_p, Aperm_i, iwork, Lnz, etree);
 
 	if (sum_Lnz < 0)
 		throw std::runtime_error(std::string("Error in computing elimination tree. Matrix not properly upper-triangular, sum_Lnz = ") + std::to_string(sum_Lnz));
@@ -75,7 +75,25 @@ Solver::Solver(QDLDL_int n, QDLDL_int * Ap, QDLDL_int *Ai, QDLDL_float * Ax){
 }
 
 
+QDLDL_float * Solver::get_D(){
+    return D;
+}
 
+QDLDL_int * Solver::get_P(){
+    return P;
+}
+
+QDLDL_int * Solver::get_Lp(){
+    return Lp;
+}
+
+QDLDL_int * Solver::get_Li(){
+    return Li;
+}
+
+QDLDL_float * Solver::get_Lx(){
+    return Lx;
+}
 
 QDLDL_float * Solver::solve(QDLDL_float * b){
 

--- a/cpp/qdldl.hpp
+++ b/cpp/qdldl.hpp
@@ -40,10 +40,18 @@ class Solver {
 	public:
 		QDLDL_int nx; // Size
 		QDLDL_int nnz; // Number of nonzero elements in the matrix
+		QDLDL_int sum_Lnz; // Number of nonzero elements in the factor L
 
 		Solver(QDLDL_int n, QDLDL_int * Ap, QDLDL_int *Ai, QDLDL_float * Ax);
 		QDLDL_float * solve(QDLDL_float * b);
 		void update(QDLDL_float * Anew_x);
+
+        QDLDL_float *get_D();
+        QDLDL_int *get_Lp();
+        QDLDL_int *get_Li();
+        QDLDL_float *get_Lx();
+        QDLDL_int *get_P();
+
 		~Solver();
 
 };

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -131,5 +131,15 @@ PYBIND11_MODULE(qdldl, m) {
 	  .def(py::init<py::object, bool>(), py::arg("A"), py::arg("upper") = false)
 	  .def("solve", &PySolver::solve)
 	  .def("update", &PySolver::update, py::arg("Anew"), py::arg("upper") = false)
-	  .def("factors", &PySolver::factors);
+	  .def("factors", &PySolver::factors, R"delim(
+            factors returns a sparse n x n matrix L, a n-array d and a list of
+            indexes p that represent the decomposition of A.
+
+            Specifically,
+            A == P @ (spa.eye(n) + L) @ spa.diags(d)  @ (spa.eye(n) + L).T @ P.T
+            where P is the matrix given by
+            P = spa.dok_matrix((n, n))
+            P[p, np.arange(n)] = 1.0
+            P = P.tocsr()
+)delim");
 }

--- a/cpp/wrapper.cpp
+++ b/cpp/wrapper.cpp
@@ -12,6 +12,7 @@ class PySolver{
 		PySolver(py::object A, const bool upper);
 		py::array solve(py::array_t<QDLDL_float, py::array::c_style | py::array::forcecast> b_py);
 		void update(py::object Anew_py, const bool upper);
+		py::tuple factors();
 
 	private:
 		std::unique_ptr<qdldl::Solver> s;
@@ -60,6 +61,25 @@ void PySolver::update(py::object Anew, const bool upper=false){
     py::gil_scoped_acquire acquire;
 }
 
+py::tuple PySolver::factors() {
+
+	py::object spa = py::module::import("scipy.sparse");
+
+    QDLDL_int n = s->nx;
+    QDLDL_int Lnz = s->sum_Lnz;
+    py::array Lp = py::array(n+1, s->get_Lp());
+    py::array Li = py::array(Lnz, s->get_Li());
+    py::array Lx = py::array(Lnz, s->get_Lx());
+
+    auto L = spa.attr("csc_matrix")(
+         py::make_tuple(Lx, Li, Lp), py::make_tuple(n, n)
+    );
+
+    py::array D = py::array(n, s->get_D());
+    py::array P = py::array(n, s->get_P());
+
+    return py::make_tuple(L, D, P);
+}
 
 
 PySolver::PySolver(py::object A, const bool upper=false){
@@ -110,5 +130,6 @@ PYBIND11_MODULE(qdldl, m) {
   py::class_<PySolver>(m, "Solver")
 	  .def(py::init<py::object, bool>(), py::arg("A"), py::arg("upper") = false)
 	  .def("solve", &PySolver::solve)
-	  .def("update", &PySolver::update, py::arg("Anew"), py::arg("upper") = false);
+	  .def("update", &PySolver::update, py::arg("Anew"), py::arg("upper") = false)
+	  .def("factors", &PySolver::factors);
 }

--- a/tests/test_factors.py
+++ b/tests/test_factors.py
@@ -1,0 +1,39 @@
+import qdldl
+import scipy.sparse as spa
+import scipy.sparse.linalg as sla
+from .utils import random_psd
+import numpy as np
+from multiprocessing.pool import ThreadPool
+
+# Unit Test
+import unittest
+import numpy.testing as nptest
+from time import time
+
+
+class factors(unittest.TestCase):
+
+    def setUp(self):
+        np.random.seed(2)
+
+    def test_basic_ls(self):
+        np.random.seed(2)
+        n = 5
+        A = random_psd(n, n)
+        B = random_psd(n, n)
+        C = - random_psd(n, n)
+        M = spa.bmat([[A, B.T], [B, C]], format='csc')
+
+        #  import ipdb; ipdb.set_trace()
+        m = qdldl.Solver(M)
+        L, D, p = m.factors()
+        L = L.toarray()
+        nptest.assert_array_almost_equal(np.triu(L), np.zeros((2 * n, 2 * n)))
+        assert (np.sort(p) == np.arange(2 * n)).all()
+
+        P = np.zeros((2*n, 2*n))
+        P[np.arange(2 * n), p] = 1
+
+        L += np.eye(2 * n)
+        # Assert close
+        nptest.assert_array_almost_equal(P @ L @ np.diag(D) @ L.T @ P.T, M.toarray())


### PR DESCRIPTION
Adds a function that returns `L, D, P` to `Solver`.

I still need to add tests, but I wanted to open this and see what people think.

Here was my development test case: 

```
import numpy as np
import scipy.sparse as sp
import qdldl

A = np.random.rand(10, 10)
A = A.T @ A

Acsc = sp.csc_matrix(A)
q = qdldl.Solver(Acsc)
L, D, P = q.factors()
L = L + sp.eye(10)
print(np.linalg.norm(L @ np.diag(D) @ L.T - A))
```