### PR TITLE
setup.py: Remove outdated `setup_requires`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,6 @@ setup(name='qdldl',
       long_description_content_type='text/markdown',
       package_dir={'qdldl': 'module'},
       include_package_data=True,  # Include package data from MANIFEST.in
-      setup_requires=["setuptools>=18.0", "pybind11"],
       install_requires=["numpy >= 1.7", "scipy >= 0.13.2"],
       license='Apache 2.0',
       url="https://github.com/oxfordcontrol/qdldl-python/",


### PR DESCRIPTION
This has been superseded by the declarations in `pyproject.toml`. Removing it will suppress the message `_DeprecatedInstaller: setuptools.installer and fetch_build_eggs are deprecated.` upon installing the package.
