### PR TITLE
Update software versions in CI, including enabling Python 3.12 wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,10 +26,10 @@ jobs:
       run: |
         choco install windows-sdk-8.1
 
-    - uses: actions/setup-python@v1
+    - uses: actions/setup-python@v5
       name: Install Python
       with:
-        python-version: '3.7'
+        python-version: '3.12'
 
     - name: Build wheels
       env:
@@ -42,13 +42,13 @@ jobs:
         CIBW_ENVIRONMENT_MACOS: CMAKE_GENERATOR="Unix Makefiles"
         CIBW_ENVIRONMENT_WINDOWS: CMAKE_GENERATOR="Visual Studio 17 2022" CMAKE_GENERATOR_PLATFORM=x64
       run: |
-        python -m pip install cibuildwheel
+        python -m pip install cibuildwheel build
         python -m cibuildwheel --output-dir wheelhouse
 
     - name: Build source
       if: startsWith(matrix.os, 'ubuntu')
       run: |
-        python setup.py sdist --dist-dir=wheelhouse
+        python -m build --sdist --outdir=wheelhouse
 
     - name: Release to pypi
       if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         submodules: 'recursive'
 
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v2
       if: startsWith(matrix.os,'windows')
 
     - name: Add Windows SDK

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,19 @@ jobs:
         twine upload wheelhouse/*
 
     - name: Upload artifacts to github
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
-        name: wheels
+        name: wheels-${{ matrix.os }}
         path: ./wheelhouse
+
+  merge_artifacts:
+    name: Merge wheel artifacts from build_wheels OS matrix jobs
+    runs-on: ubuntu-latest
+    needs: build_wheels
+    steps:
+      - name: Merge artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: wheels
+          pattern: wheels-*
+          delete-merged: true


### PR DESCRIPTION
The main purpose of this PR is to update the version of Python used in CI to generate the wheel files. The current version is Python 3.7 which is out of support. Using 3.7 leads to outdated versions of setuptools and cibuildwheel being installed. Most significantly, this means that the version of cibuildwheel used does not build wheels for Python 3.12.

While updating the Python version, I noticed warnings about GitHub actions versions being outdated and going out of support soon, so I updated them as well. That work could be split out of the PR if preferred.

Detailed list of distinct changes:

* Update CI Python to 3.12 (cibuildwheel still runs Python 3.6-3.11 and now runs 3.12 as well).
* Replace `python setup.py sdist` with `python -m build --sdist` since the former was deprecated and does not work with the latest setuptools.
* Update setup-python action from v1 to v5
* Update setup-msbuild from v1.0.2 to v2
* Update upload-artifact from v1 to v5
* Add a step to merge artifacts to maintain the behavior of a single wheels.zip artifact. The new upload-artifact does not support mutating an artifact after upload. Alternatively, this setup could be dropped and there could just be separate .zip files for each OS.