### PR TITLE
Update build wheels to build both arm and x86 macos wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,9 +39,12 @@ jobs:
         CIBW_MANYLINUX_X86_64_IMAGE: "dockcross/manylinux2014-x64"
         CIBW_TEST_REQUIRES: "pytest"
         CIBW_TEST_COMMAND: "pytest {project}/tests"
+        # Skip testing on arm64 Python 3.8 because it uses the x86_64 executable, not the arm executable
+        CIBW_TEST_SKIP: "cp38-macosx_*:arm64"
         CIBW_ENVIRONMENT_LINUX: CMAKE_GENERATOR="Unix Makefiles"
         CIBW_ENVIRONMENT_MACOS: CMAKE_GENERATOR="Unix Makefiles"
         CIBW_ENVIRONMENT_WINDOWS: CMAKE_GENERATOR="Visual Studio 17 2022" CMAKE_GENERATOR_PLATFORM=x64
+        CIBW_BUILD_VERBOSITY: 1
       run: |
         python -m pip install cibuildwheel build
         python -m cibuildwheel --output-dir wheelhouse

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-2022]
+        # Include macos-13 to get Intel x86_64 macs and maos-latest to get the Aaarch64 macs
+        os: [ubuntu-latest, macos-latest, macos-13, windows-2022]
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,12 @@ jobs:
         # Include macos-13 to get Intel x86_64 macs and maos-latest to get the Aaarch64 macs
         os: [ubuntu-latest, macos-latest, macos-13, windows-2022]
 
+        # Build on the native architectures (macos-latest is arm64. macos-13 is x86_64)
+        include:
+        - os: macos-latest
+          osx_arch: 'arm64'
+        - os: macos-13
+          osx_arch: 'x86_64'
     steps:
     - uses: actions/checkout@master
       with:
@@ -42,7 +48,7 @@ jobs:
         # Skip testing on arm64 Python 3.8 because it uses the x86_64 executable, not the arm executable
         CIBW_TEST_SKIP: "cp38-macosx_*:arm64"
         CIBW_ENVIRONMENT_LINUX: CMAKE_GENERATOR="Unix Makefiles"
-        CIBW_ENVIRONMENT_MACOS: CMAKE_GENERATOR="Unix Makefiles"
+        CIBW_ENVIRONMENT_MACOS: CMAKE_GENERATOR="Unix Makefiles" CMAKE_OSX_ARCHITECTURES=${{ matrix.osx_arch }}
         CIBW_ENVIRONMENT_WINDOWS: CMAKE_GENERATOR="Visual Studio 17 2022" CMAKE_GENERATOR_PLATFORM=x64
         CIBW_BUILD_VERBOSITY: 1
       run: |

--- a/c/CMakeLists.txt
+++ b/c/CMakeLists.txt
@@ -1,7 +1,11 @@
-cmake_minimum_required (VERSION 3.2)
+cmake_minimum_required (VERSION 3.5)
 
 # Project name
 project (qdldl_amd)
+
+if(APPLE)
+    message(STATUS "Building for Apple arches: ${CMAKE_OSX_ARCHITECTURES}")
+endif()
 
 # Needed for compilation to succeed
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/setup.py
+++ b/setup.py
@@ -35,14 +35,14 @@ class get_pybind_include(object):
 
 cmake_args = []
 # What variables from the environment do we wish to pass on to cmake as variables?
-cmake_env_vars = ('CMAKE_GENERATOR', 'CMAKE_GENERATOR_PLATFORM')
+cmake_env_vars = ('CMAKE_GENERATOR', 'CMAKE_GENERATOR_PLATFORM', 'CMAKE_OSX_ARCHITECTURES')
 for cmake_env_var in cmake_env_vars:
     cmake_var = os.environ.get(cmake_env_var)
     if cmake_var:
         cmake_args.extend([f'-D{cmake_env_var}={cmake_var}'])
 
 # Add parameters to cmake_args and define_macros
-cmake_args += ["-DUNITTESTS=OFF"]
+cmake_args += ["-DQDLDL_UNITTESTS=OFF"]
 cmake_build_flags = []
 lib_subdir = []
 


### PR DESCRIPTION
Github updated the macos-latest runners to be macOS 14 and the M-series aarch64 hardware, so to build both wheels, we need to run on both the new `macos-latest` and the old `macos-13` images.