### PR TITLE
Add dependabot for GitHub actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,7 @@
+# Check the GitHub actions for updates
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: "weekly"


### PR DESCRIPTION
Add dependabot for GitHub actions to keep them up-to-date.