### PR TITLE
Cleanup wheel building CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
         CIBW_TEST_SKIP: "cp38-macosx_*:arm64"
         # Clean the build directory between builds
         CIBW_BEFORE_BUILD: >-
-          rm -rf {package}/build
+          rm -rf {package}/c/build
         CIBW_ENVIRONMENT_LINUX: CMAKE_GENERATOR="Unix Makefiles"
         CIBW_ENVIRONMENT_MACOS: CMAKE_GENERATOR="Unix Makefiles" CMAKE_OSX_ARCHITECTURES=${{ matrix.osx_arch }}
         CIBW_ENVIRONMENT_WINDOWS: CMAKE_GENERATOR="Visual Studio 17 2022" CMAKE_GENERATOR_PLATFORM=x64

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,6 +39,7 @@ jobs:
         python-version: '3.12'
 
     - name: Build wheels
+      uses: pypa/cibuildwheel@v2.19.1
       env:
         CIBW_BUILD: "cp3*"
         CIBW_SKIP: "*-win32 *-manylinux_i686 *-musllinux_*"
@@ -47,13 +48,13 @@ jobs:
         CIBW_TEST_COMMAND: "pytest {project}/tests"
         # Skip testing on arm64 Python 3.8 because it uses the x86_64 executable, not the arm executable
         CIBW_TEST_SKIP: "cp38-macosx_*:arm64"
+        # Clean the build directory between builds
+        CIBW_BEFORE_BUILD: >-
+          rm -rf {package}/build
         CIBW_ENVIRONMENT_LINUX: CMAKE_GENERATOR="Unix Makefiles"
         CIBW_ENVIRONMENT_MACOS: CMAKE_GENERATOR="Unix Makefiles" CMAKE_OSX_ARCHITECTURES=${{ matrix.osx_arch }}
         CIBW_ENVIRONMENT_WINDOWS: CMAKE_GENERATOR="Visual Studio 17 2022" CMAKE_GENERATOR_PLATFORM=x64
         CIBW_BUILD_VERBOSITY: 1
-      run: |
-        python -m pip install cibuildwheel build
-        python -m cibuildwheel --output-dir wheelhouse
 
     - name: Build source
       if: startsWith(matrix.os, 'ubuntu')
@@ -74,6 +75,7 @@ jobs:
       with:
         name: wheels-${{ matrix.os }}
         path: ./wheelhouse
+        if-no-files-found: error
 
   merge_artifacts:
     name: Merge wheel artifacts from build_wheels OS matrix jobs

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,36 @@
-name: Build
+name: Build wheels
 
 on: [push, pull_request]
 
 jobs:
+  build_sdist:
+    name: Build source
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@master
+      with:
+        submodules: 'recursive'
+
+    - uses: actions/setup-python@v5
+      name: Install Python
+      with:
+        python-version: '3.12'
+
+    - name: Build source
+      run: |
+        python -m pip install build
+        python -m build --sdist --outdir=wheelhouse
+
+    - name: Upload sdist to github
+      uses: actions/upload-artifact@v4
+      with:
+        name: wheels-sdist
+        path: wheelhouse/*.tar.gz
+        if-no-files-found: error
+
   build_wheels:
     name: Build wheel on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -56,35 +84,34 @@ jobs:
         CIBW_ENVIRONMENT_WINDOWS: CMAKE_GENERATOR="Visual Studio 17 2022" CMAKE_GENERATOR_PLATFORM=x64
         CIBW_BUILD_VERBOSITY: 1
 
-    - name: Build source
-      if: startsWith(matrix.os, 'ubuntu')
-      run: |
-        python -m build --sdist --outdir=wheelhouse
-
-    - name: Release to pypi
-      if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.pypi_password }}
-      run: |
-        python -m pip install --upgrade twine
-        twine upload wheelhouse/*
-
     - name: Upload artifacts to github
       uses: actions/upload-artifact@v4
       with:
         name: wheels-${{ matrix.os }}
-        path: ./wheelhouse
+        path: ./wheelhouse/*.whl
         if-no-files-found: error
 
-  merge_artifacts:
-    name: Merge wheel artifacts from build_wheels OS matrix jobs
+  publish_to_pypi:
+    name: Publish wheels to PyPi
+    if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
+    needs: [build_sdist, build_wheels]
     runs-on: ubuntu-latest
-    needs: build_wheels
+
     steps:
-      - name: Merge artifacts
-        uses: actions/upload-artifact/merge@v4
+      - name: Download packages
+        uses: actions/download-artifact@v4
         with:
-          name: wheels
           pattern: wheels-*
-          delete-merged: true
+          path: wheelhouse
+          merge-multiple: true
+
+      - name: Print out packages
+        run: ls wheelhouse
+
+      - name: Upload wheels to pypi
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.pypi_password }}
+        run: |
+          python -m pip install --upgrade twine
+          twine upload wheelhouse/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-
     steps:
     - uses: actions/checkout@master
       with:
@@ -91,19 +90,31 @@ jobs:
         path: ./wheelhouse/*.whl
         if-no-files-found: error
 
+
+  merge_wheel_artifacts:
+    name: Merge wheel artifacts
+    runs-on: ubuntu-latest
+    needs: [build_sdist, build_wheels]
+    steps:
+      - name: Merge artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: wheels
+          pattern: wheels-*
+          delete-merged: true
+
+
   publish_to_pypi:
     name: Publish wheels to PyPi
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
-    needs: [build_sdist, build_wheels]
+    needs: merge_wheel_artifacts
     runs-on: ubuntu-latest
-
     steps:
       - name: Download packages
         uses: actions/download-artifact@v4
         with:
-          pattern: wheels-*
+          pattern: wheels*
           path: wheelhouse
-          merge-multiple: true
 
       - name: Print out packages
         run: ls wheelhouse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,12 @@
 [build-system]
-requires = ["setuptools>=49.5.0", "pybind11", "cmake"]
+requires = [
+    # Building with numpy 2.0 is compatible with numpy 1.x, but it
+    # is only available on Python 3.9+
+    "numpy >= 2.0.0; python_version > '3.8'",
+    "oldest-supported-numpy; python_version <= '3.8'",
+    "setuptools>=49.5.0",
+    "pybind11",
+    "cmake"
+]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
This PR does a clean-up to the wheel building CI, and works on improving it.

Specifically, it:
* Switches to using the `cibuildwheel` action instead of doing the install/invocation ourselves
* Delete the build directory between each build to ensure we start fresh for each version
* Separate the source build and wheel upload into a separate step