### PR TITLE
Build the aarch64 wheels on new aarch64 linux runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         include:
           - os: ubuntu-latest
             cibw_archs: "x86_64"
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             cibw_archs: "aarch64"
           - os: windows-2022
             cibw_archs: "auto64"
@@ -53,13 +53,6 @@ jobs:
     - uses: actions/checkout@master
       with:
         submodules: 'recursive'
-
-      # This might not be necessary once ARM runners become available for general use
-    - name: Set up QEMU
-      if: matrix.cibw_archs == 'aarch64'
-      uses: docker/setup-qemu-action@v3
-      with:
-        platforms: arm64
 
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v2


### PR DESCRIPTION
These aarch64 runners are now free for public repos: https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/