### PR TITLE
Add `cmake` dependency only if no system CMake is available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ requires = [
     "oldest-supported-numpy; python_version <= '3.8'",
     "setuptools>=49.5.0",
     "pybind11",
-    "cmake"
 ]
 build-backend = "setuptools.build_meta"
 

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,9 @@ class get_pybind_include(object):
         import pybind11
         return pybind11.get_include(self.user)
 
+setup_requires = []
+if not sh.which("cmake"):
+    setup_requires += ["cmake"]
 
 cmake_args = []
 # What variables from the environment do we wish to pass on to cmake as variables?
@@ -119,6 +122,7 @@ setup(name='qdldl',
       long_description_content_type='text/markdown',
       package_dir={'qdldl': 'module'},
       include_package_data=True,  # Include package data from MANIFEST.in
+      setup_requires=setup_requires,
       install_requires=["numpy >= 1.7", "scipy >= 0.13.2"],
       license='Apache 2.0',
       url="https://github.com/oxfordcontrol/qdldl-python/",


### PR DESCRIPTION
Add a `cmake` dependency only when there is no system CMake install available.  This avoids unnnecessarily installing a second copy of CMake on most systems, and increases compatibility with platforms that need downstream patching of CMake.